### PR TITLE
csv table inline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+node_modules

--- a/docs/reference/data-formats/csv-submissions/csv-submissions.md
+++ b/docs/reference/data-formats/csv-submissions/csv-submissions.md
@@ -1,26 +1,23 @@
 ---
-
 title: Proper CSV Formatting for Geoconnex
-
 ---
 
 # Proper CSV Formatting for Geoconnex
+
 :::note
 
 For a tutorial on how to submit your CSV data see [the contribution tutorial](../../../contributing/step-3/minting.md)
 
 :::
 
-Geoconnex expects a standard format for the CSVs which maps a persistent identifier in Geoconnex to one of your resources. You must include at least the following 4 columns:
+Geoconnex expects a standard format for the CSVs which maps a persistent identifier in Geoconnex to a single data resource. You must include at least the following 4 columns:
 
-| Column Title | Description                                                                 |
-|--------------|-----------------------------------------------------------------------------|
-| `id`        | The ID within geoconnex that your data should map to.                      |
-| `target`    | The endpoint where the JSON-LD for the resource can be found.              |
-| `creator`   | The contact email associated with the resource.                             |
-| `description` | A natural language description of the data.                                |
-
-
+| Column Title  | Description                                                                                                                                                        |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`          | The ID within geoconnex that your data should map to. These are unique, will redirect to the associated target, and are meant for individual monitoring locations. View [the identification scheme](/contributing/step-1/idscheme) section for more info. |
+| `target`      | The URL pointing to a JSON-LD landing page for a single feature in your data.                                                                                      |
+| `creator`     | A contact email for someone associated with the resource.                                                                                                          |
+| `description` | A natural language description of the data.                                                                                                                        |
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -30,33 +27,41 @@ import TabItem from '@theme/TabItem';
 <Tabs>
   <TabItem value="github" label="1:1 Redirects" default>
 
-There is a strong preference for creating 1:1 redirects. That is, specifying an exact redirect from a geoconnex.us-based PID to the URI of the hydrologic feature you have a web resource about, for each and every individual feature. 
+There is a strong preference for creating 1:1 redirects. That is, specifying an exact redirect from a geoconnex.us-based PID to the URI of the hydrologic feature you have a web resource about, for each and every individual feature.
+
+<!-- We need to put this behind a div and not use ## for a header since the header would be rendered
+in the docusaurus sidebar even if it is in the othertab that isn't opened -->
+<div style={{ fontSize: '24px', fontWeight: 'bold', marginTop: '20px' }}>
+  An example 1:1 mapping
+
+</div>
 
 
-An example 1:1 mapping can be found [here](https://github.com/internetofwater/geoconnex.us/blob/master/namespaces/SELFIE/SELFIE_ids.csv).
+import CSVTable from '@site/src/components/CSVTable';
 
+<CSVTable csvUrl="https://raw.githubusercontent.com/internetofwater/geoconnex.us/master/namespaces/iow/demo.csv" />
 
-For information regarding submitting CSV redirects see [the tutorial for minting persistent identifiers](/contributing/step-3/minting)
   </TabItem>
   <TabItem value="register" label="1:N Regex Redirects">
 
-  :::caution
+:::caution
 
 Unless you have more than 300,000 features and cannot use 1:1 redirects, you should avoid using regex redirects as they are harder to resolve and maintain if endpoints change
 
 :::
-  If you need to create PIDs and redirects for a large number of features (more than 300,000), _and cannot use 1:1 redirects_, we will require a regular expression matching redirect.
+If you need to create PIDs and redirects for a large number of features (more than 300,000), _and cannot use 1:1 redirects_, we will require a regular expression matching redirect.
 
-   - For example, redirecting from https://geoconnex.us/example-namespace/*wildcard-string to https://example.org/features?query=*wildcard-string.
+- For example, redirecting from https://geoconnex.us/example-namespace/*wildcard-string to https://example.org/features?query=*wildcard-string.
 
-    - If you have more than 300,000 features, but these features can be split in a consistent way into sub-collections, all of which number less than 300,000 features (as might be the case for features that can be divided by geography, jurisdiction, theme, or type), then you might consider submitting multiple collections of 1:1 redirects.
+- If you have more than 300,000 features, but these features can be split in a consistent way into sub-collections, all of which number less than 300,000 features (as might be the case for features that can be divided by geography, jurisdiction, theme, or type), then you might consider submitting multiple collections of 1:1 redirects.
 
 To submit a request to submit this data, you can [create an issue of type "Request regex redirect"](https://github.com/internetofwater/geoconnex.us/issues/new?assignees=dblodgett-usgs%2C+ksonda&labels=PID+request&template=request-regex-redirect.md&title=[regex+redirect+request) and fill out the template.
 
+<div style={{ fontSize: '24px', fontWeight: 'bold', marginTop: '20px' }}>
+An example 1:N mapping that uses a regular expression
 
-An example 1:N mapping that uses regexes can be found [here](https://github.com/internetofwater/geoconnex.us/blob/master/namespaces/usgs/monitoring-location/monitoring-location.csv)
-    
+</div>
 
+<CSVTable csvUrl="https://raw.githubusercontent.com/internetofwater/geoconnex.us/master/namespaces/usgs/monitoring-location/monitoring-location.csv" />
   </TabItem>
 </Tabs>
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mdx-js/react": "^3.0.0",
         "@tippyjs/react": "^4.2.6",
         "clsx": "^2.0.0",
+        "papaparse": "^5.4.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -11923,6 +11924,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
+      "license": "MIT"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -16148,6 +16155,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "plugins/my-loaders": {
+      "version": "0.0.0",
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mdx-js/react": "^3.0.0",
     "@tippyjs/react": "^4.2.6",
     "clsx": "^2.0.0",
+    "papaparse": "^5.4.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"

--- a/src/components/CSVTable.tsx
+++ b/src/components/CSVTable.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from "react";
+import Papa from "papaparse";
+
+const CSVTable = ({ csvUrl }) => {
+  const [data, setData] = useState([]);
+  const [headers, setHeaders] = useState([]);
+  const [displayUrl, setDisplayUrl] = useState(csvUrl);
+
+  useEffect(() => {
+    const fetchCSV = async () => {
+      try {
+        if (csvUrl) {
+          const response = await fetch(csvUrl);
+          const csvText = await response.text();
+          parseCSV(csvText);
+
+          // Convert raw GitHub URL to normal GitHub UI URL if applicable
+          let displayUrl = csvUrl;
+          if (csvUrl.includes("raw.githubusercontent.com")) {
+            displayUrl = csvUrl
+              .replace("raw.githubusercontent.com", "github.com")
+              .replace("/master/", "/blob/master/");
+          }
+
+          setDisplayUrl(displayUrl);
+        }
+      } catch (error) {
+        console.error("Error fetching or parsing CSV:", error);
+      }
+    };
+
+    const parseCSV = (csvText) => {
+      const parsedData = Papa.parse(csvText, {
+        header: true,
+        skipEmptyLines: true,
+      });
+
+      setHeaders(parsedData.meta.fields);
+      setData(parsedData.data);
+    };
+
+    fetchCSV();
+  }, [csvUrl]);
+
+  const rowsToShow = 10
+  const limitedData = data.slice(0, rowsToShow);
+  const isAbbreviated = data.length > rowsToShow;
+  const abbreviatedCount = data.length - limitedData.length;
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <thead>
+          <tr>
+            <th
+              colSpan={headers.length}
+              style={{
+                borderBottom: "2px solid #ccc",
+                padding: "10px",
+                textAlign: "left",
+                fontSize: "18px",
+                fontWeight: "bold",
+              }}
+            >
+              Source: <a href={displayUrl} target="_blank" rel="noopener noreferrer">{new URL(displayUrl).pathname.split('/').pop()}</a>
+            </th>
+          </tr>
+          <tr>
+            {headers.map((header, index) => (
+              <th
+                key={index}
+                style={{
+                  borderBottom: "2px solid #ccc",
+                  padding: "10px",
+                  textAlign: "left",
+                }}
+              >
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {limitedData.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {headers.map((header, colIndex) => (
+                <td
+                  key={colIndex}
+                  style={{
+                    borderBottom: "1px solid #ddd",
+                    padding: "8px",
+                  }}
+                >
+                  {row[header]}
+                </td>
+              ))}
+            </tr>
+          ))}
+          {isAbbreviated && (
+            <tr>
+              <td colSpan={headers.length} style={{ textAlign: "left" }}>
+                ...with {abbreviatedCount} more rows abbreviated for brevity
+                              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default CSVTable;


### PR DESCRIPTION
- adds a new React component `CSVTable` that we can use to display a remote CSVs as a table inline. 
    - reduces friction for new users by directly linking the CSV in the same docs page
- made csv documentation wording more similar across the register and docs sites
- added a table for the 1:1 and 1:N example
-  updated the 1:1 and 1:N examples to be the same examples that were in register.geoconnex.us before they were removed