### PR TITLE
Add proper cors headers to netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+for = "/*" 
+[headers.values]
+Access-Control-Allow-Origin = "*" 


### PR DESCRIPTION
For the sparql query service, we need to be able to fetch examples that are located on the docs site itself. So for this to work we need to have the proper cors headers. This is accomplished by setting this in the netlify toml.

We don’t use cookies, authentication headers, or private data in requests so there isn't much downside to this