### PR TITLE
Add better sparql ui 

### DIFF
--- a/docs/access/examples/datasets.md
+++ b/docs/access/examples/datasets.md
@@ -268,7 +268,7 @@ curl -X POST --header 'Accept: application/sparql-results+json' --header 'Conten
 
   <TabItem value="editor" label="Graphically">
 
-  Since [graph.geoconnex.us](https://graph.geoconnex.us) is a public SPARQL endpoint, it can be used with a variety of SPARQL editors. One such example is included in the playground section of the docs, titled [SPARQL Query Builder](/playground/sparql).
+  Since [graph.geoconnex.us](https://graph.geoconnex.us) is a public SPARQL endpoint, it can be used with a variety of SPARQL editors. One such example is included in the playground section of the docs, titled [SPARQL Query Helper](/playground/sparql).
 </TabItem>
 
 </Tabs>

--- a/docs/playground/sparql.md
+++ b/docs/playground/sparql.md
@@ -31,10 +31,12 @@ import TabItem from '@theme/TabItem';
 
   <TabItem value="help" label="Help and Background Info">
     <div style={{fontSize: "1.5em", fontWeight: "bold", margin: "1em 0 0.5em 0"}}>
-      SPARQL Query Builder Overview
+      SPARQL Query Helper Overview
     </div>
 
     This page allows you to create SPARQL queries to fetch data from the Geoconnex graph database located at [graph.geoconnex.us](https://graph.geoconnex.us). Since the Geoconnex graph database has a public endpoint, you can use both this page or any HTTP client to fetch data.
+
+    If your query returns well-known-text (wkt) geometry, you can view it on a map by changing the output from `Table` to `Map` in the bottom left of the editor.
 
     For more detail about accessing data in Geoconnex, view the [access data](/access/overview) section generally and the [SPARQL section](/access/examples/datasets#sparql) in particular.
   </TabItem>


### PR DESCRIPTION
Add an iframe for the wikidata sparql editor pointed to Geoconnex. This is in my opinion much better than yasgui and supports a map and other interesting output formats. It also supports programmatic query exports i.e. for python or R automatically. 

I have added a few nice sample queries

It sources our fork of the wikidata query UI here:
https://github.com/internetofwater/wikidata-query-gui This is essentially a fork that allows for better usage with geoconnex. 