### PR TITLE
Add shacl shape info to documentation

### DIFF
--- a/docs/reference/data-formats/shacl_shape.md
+++ b/docs/reference/data-formats/shacl_shape.md
@@ -1,0 +1,16 @@
+# SHACL Shape
+import ShaclShape from '@site/src/components/ShaclShape';
+
+[SHACL](https://en.wikipedia.org/wiki/SHACL), also known as Shapes Constraint Language, is a format for defining constraints on data in a knowledge graph. It is a subset of [RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework) and can be used to validate your JSON-LD data before it is added to the Geoconnex system.
+
+
+This shape below ensures your data conforms to either the Location or Dataset formats presented in the [Geoconnex Specifics section](./jsonld/primer/index.md) of the documentation. 
+
+:::note
+In order to use this shape and check your JSON-LD, your data must have a JSON-LD key named `@type` with a value of either `schema:Place` or `schema:Dataset`. This signifies that it is either a dataset or a location. Otherwise shacl will skip checking it. For more info on JSON-LD generally, see the [JSON-LD section](./jsonld/overview.md) of the docs.
+
+This shape is in active development and may be updated in the future.
+:::
+
+
+<ShaclShape url="https://raw.githubusercontent.com/internetofwater/nabu/refs/heads/main/shacl_validator/shapes/locationOriented.ttl" />

--- a/src/components/ShaclShape.tsx
+++ b/src/components/ShaclShape.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from "react";
+import CodeBlock from "@theme/CodeBlock";
+
+const ShaclShape = ({ url }) => {
+  const [ttlContent, setTtlContent] = useState("");
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchShape = async () => {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const text = await response.text();
+        setTtlContent(text);
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+
+    fetchShape();
+  }, [url]);
+
+  if (error) {
+    return (
+      <div style={{ color: "red" }}>Error loading SHACL shape: {error}</div>
+    );
+  }
+
+  if (!ttlContent) {
+    return <div>Loading SHACL shape...</div>;
+  }
+
+  return <CodeBlock className="language-turtle">{ttlContent}</CodeBlock>;
+};
+
+export default ShaclShape;


### PR DESCRIPTION
Now that the shacl shape is in a reasonable place, it can be added to the docs. Eventually I will add a playground that a user can use to dynamically test their jsonld. However, I think it is also useful to put in the direct shape itself. 

This will also be useful for our own team to reference since it is dynamically fetched and thus is always up to date with the source of truth of our shacl shape. 

This info can thus now be found at `/reference/data-formats/shacl_shape`