### PR TITLE
Make access data link to the sparql query playground

### DIFF
--- a/src/components/CardLinks.tsx
+++ b/src/components/CardLinks.tsx
@@ -39,7 +39,7 @@ const CardLinks = () => {
         />
         <div style={{ marginTop: '12px' }}>
           <a
-            href="https://graph.geoconnex.us"
+            href="/playground/sparql"
             style={{
               display: 'inline-block',
               padding: '4px 8px',


### PR DESCRIPTION
since graph.geoconnex.us doesnt have a stable frontend, make the access data page link to the sparql query playground