### PR TITLE
fix: typo 'Geoconenx' --> 'Geoconnex'

### DIFF
--- a/docs/about/system-architecture/repositories.md
+++ b/docs/about/system-architecture/repositories.md
@@ -6,7 +6,7 @@
 | Repo name| Description |
 |-------------|-------------|
 | [geoconnex.us](https://github.com/internetofwater/geoconnex.us) | PID registry for hydrologic, environmental, and administrative features |
-| [register.geoconnex.us](https://github.com/internetofwater/register.geoconnex.us) | Helper web application for submitting PIDs to Geoconenx without a GitHub account |
+| [register.geoconnex.us](https://github.com/internetofwater/register.geoconnex.us) | Helper web application for submitting PIDs to Geoconnex without a GitHub account |
 | [about.geoconnex.us](https://github.com/internetofwater/about.geoconnex.us) | An overview of all geoconnex repos | 
 | [pids.geoconnex.us](https://github.com/internetofwater/pids.geoconnex.us) | Development and deployment of PID server, database, and sitemap.xml assets |
 | [harvest.geoconnex.us](https://github.com/internetofwater/harvest.geoconnex.us) | Customization and deployment of gleaner for harvesting linked data |

--- a/docs/access/examples/identifying/spatial.md
+++ b/docs/access/examples/identifying/spatial.md
@@ -197,7 +197,7 @@ folium.Marker(
 </TabItem>
 </Tabs>
 
-Here we see that our field site is in the HUC10 1408010505, which has the associated Geoconnex URI https://geoconnex.us/ref/hu10/1408010505. This identifier can be used if we were to publish data about our site, following [Geoconenx guidance and best practices](https://docs.geoconnex.us/contributing/step-1/dataprep).
+Here we see that our field site is in the HUC10 1408010505, which has the associated Geoconnex URI https://geoconnex.us/ref/hu10/1408010505. This identifier can be used if we were to publish data about our site, following [Geoconnex guidance and best practices](https://docs.geoconnex.us/contributing/step-1/dataprep).
 
 ### Intersection by URL reference
 

--- a/docs/contributing/step-2/pygeoapi/templating.md
+++ b/docs/contributing/step-2/pygeoapi/templating.md
@@ -293,7 +293,7 @@ import TabItem from '@theme/TabItem';
   Your goal should be to make your template as generalizable as possible. For instance, we use `{% for stream in data['Datastreams'] %}` to iterate through the `Datastreams` array in the JSON-LD output and reformat the output data for each. However, in some cases if we do not have the desired data in the original JSON-LD output, we may need to hard code the info.
 
 
-  Consult the [JSON-LD Geoconenx guidance](../../../reference/data-formats/jsonld/primer/index.md) for more detailed information on which keys are required in each JSON-LD output format.
+  Consult the [JSON-LD Geoconnex guidance](../../../reference/data-formats/jsonld/primer/index.md) for more detailed information on which keys are required in each JSON-LD output format.
 
   :::note
   In general your template should be simply moving around the structure of the original output to make it more easily parsed for Geoconnex. If necessary, data that you need but is not output via your API can be hard coded. 


### PR DESCRIPTION
Fixes typos in a few places in the docs from `Geoconenx` to `Geoconnex`.