### PR TITLE
Bump geoconnex client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@vis.gl/react-maplibre": "^8.1.0",
         "clsx": "^2.0.0",
         "flatgeobuf": "^4.3.3",
-        "geoconnex-client-ts": "github:internetofwater/geoconnex-client-ts",
+        "geoconnex-client-ts": "^0.1.3",
         "maplibre-gl": "^5.14.0",
         "papaparse": "^5.4.1",
         "prism-react-renderer": "^2.3.0",
@@ -10110,12 +10110,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fzstd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
-      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
-      "license": "MIT"
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10126,12 +10120,9 @@
       }
     },
     "node_modules/geoconnex-client-ts": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/internetofwater/geoconnex-client-ts.git#62d2454d46142301577895d5e92502a96eb588bd",
-      "dependencies": {
-        "hyparquet": "^1.25.0",
-        "hyparquet-compressors": "^1.1.1"
-      },
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/geoconnex-client-ts/-/geoconnex-client-ts-0.1.3.tgz",
+      "integrity": "sha512-EmcGBwJUUGyMoULSG4X4mU3BXAB3ujxMpiWogB34DzWQudodtSJ0P3fjHCEOY5bcRFt6I5d/Sk+c+yreogAzkA==",
       "engines": {
         "node": ">=24.0.0"
       }
@@ -11095,28 +11086,6 @@
       "engines": {
         "node": ">=10.17.0"
       }
-    },
-    "node_modules/hyparquet": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.25.0.tgz",
-      "integrity": "sha512-isJx+RplYT3aJc5yhaG5CeOZSBJecHZgYsUi7NE6P/nAbxxA0hZcyul0tUsWCQLc9QXYQ2uFyYBrk61JbJO0cg==",
-      "license": "MIT"
-    },
-    "node_modules/hyparquet-compressors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
-      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
-      "license": "MIT",
-      "dependencies": {
-        "fzstd": "0.1.1",
-        "hysnappy": "1.0.0"
-      }
-    },
-    "node_modules/hysnappy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
-      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@vis.gl/react-maplibre": "^8.1.0",
     "clsx": "^2.0.0",
     "flatgeobuf": "^4.3.3",
-    "geoconnex-client-ts": "github:internetofwater/geoconnex-client-ts#62d2454d46142301577895d5e92502a96eb588bd",
+    "geoconnex-client-ts": "^0.1.3",
     "maplibre-gl": "^5.14.0",
     "papaparse": "^5.4.1",
     "prism-react-renderer": "^2.3.0",


### PR DESCRIPTION
Use the pinned npm version of the geoconnex ts client instead of a git hash